### PR TITLE
[WIP] Run rainbow example in Docker

### DIFF
--- a/example/rainbow/Dockerfile
+++ b/example/rainbow/Dockerfile
@@ -9,7 +9,7 @@ RUN glide install
 RUN go build example/rainbow/rainbow.go
 
 FROM arm32v6/alpine
-LABEL org.label-schema.docker.cmd "docker run -ti --device=/dev/ttyACM0 johnmccabe/mote-rainbow"
+LABEL org.label-schema.docker.cmd "docker run --device=/dev/ttyACM0 johnmccabe/mote-rainbow"
 LABEL org.label-schema.description "Run the Pimoroni Mote Rainbow example on your Raspberry Pi (arm32v6)"
 LABEL org.label-schema.url "https://github.com/johnmccabe/mote"
 COPY --from=0 /go/src/github.com/johnmccabe/mote/rainbow /rainbow

--- a/example/rainbow/Dockerfile
+++ b/example/rainbow/Dockerfile
@@ -1,0 +1,16 @@
+FROM arm32v6/golang:1.8-alpine
+RUN apk update
+RUN apk add git gcc musl-dev linux-headers
+RUN go get github.com/johnmccabe/mote
+RUN go get github.com/Masterminds/glide
+WORKDIR /go/src/github.com/johnmccabe/mote/
+COPY rainbow.go ./example/rainbow/
+RUN glide install
+RUN go build example/rainbow/rainbow.go
+
+FROM arm32v6/alpine
+LABEL org.label-schema.docker.cmd "docker run -ti --device=/dev/ttyACM0 johnmccabe/mote-rainbow"
+LABEL org.label-schema.description "Run the Pimoroni Mote Rainbow example on your Raspberry Pi (arm32v6)"
+LABEL org.label-schema.url "https://github.com/johnmccabe/mote"
+COPY --from=0 /go/src/github.com/johnmccabe/mote/rainbow /rainbow
+CMD ["/rainbow"]


### PR DESCRIPTION
This PR adds a multi-stage Dockerfile which builds the rainbow example on `arm32v6/alpine`.

To build run:
```
cd examples/rainbow/
docker build -t johnmccabe/mote-rainbow .
```

To run the container you either need to pass the path to the Mote devices port.
```
docker run --device=/dev/ttyACM0 johnmccabe/mote-rainbow
```
or, run with `--privileged`.
```
docker run --privileged johnmccabe/mote-rainbow
```